### PR TITLE
Preliminary support for TKG v 1.2 and TMC 0.2

### DIFF
--- a/scripts/01-prep-aws-objects.sh
+++ b/scripts/01-prep-aws-objects.sh
@@ -3,7 +3,7 @@
 TKG_LAB_SCRIPTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $TKG_LAB_SCRIPTS/set-env.sh
 
-clusterawsadm alpha bootstrap create-stack
+tkg config permissions aws
 
 export AWS_REGION=$(yq r $PARAMS_YAML aws.region)
 export AWS_ACCESS_KEY_ID=$(yq r $PARAMS_YAML aws.access-key-id)

--- a/scripts/delete-all-aws.sh
+++ b/scripts/delete-all-aws.sh
@@ -5,8 +5,8 @@ source $TKG_LAB_SCRIPTS/set-env.sh
 
 VMWARE_ID=$(yq r $PARAMS_YAML vmware-id)
 
-# tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML management-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
-# tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML shared-services-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
+tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML management-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
+tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML shared-services-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
 
 set +e
 if tmc cluster namespace get -p attached -m attached --cluster-name $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas) acme-fitness 2>&1 > /dev/null; then 
@@ -24,7 +24,7 @@ tkg set mc $(yq r $PARAMS_YAML management-cluster.name)
 tkg delete cluster $(yq r $PARAMS_YAML workload-cluster.name) --yes
 tkg delete cluster $(yq r $PARAMS_YAML shared-services-cluster.name) --yes
 
-#Wait for cert to be ready
+#Wait for cluster to be deleted
 while tkg get cluster | grep deleting ; [ $? -eq 0 ]; do
 	echo "Waiting for clusters to be deleted"
 	sleep 5s

--- a/scripts/delete-all-aws.sh
+++ b/scripts/delete-all-aws.sh
@@ -5,12 +5,20 @@ source $TKG_LAB_SCRIPTS/set-env.sh
 
 VMWARE_ID=$(yq r $PARAMS_YAML vmware-id)
 
-tmc cluster delete $VMWARE_ID-$(yq r $PARAMS_YAML management-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
-tmc cluster delete $VMWARE_ID-$(yq r $PARAMS_YAML shared-services-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
+# tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML management-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
+# tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML shared-services-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
 
-tmc cluster namespace delete acme-fitness $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas)
-tmc workspace delete $(yq r $PARAMS_YAML acme-fitness.tmc-workspace)
-tmc cluster delete $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
+set +e
+if tmc cluster namespace get -p attached -m attached --cluster-name $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas) acme-fitness 2>&1 > /dev/null; then 
+	tmc cluster namespace delete -m attached -p attached --cluster-name $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas) acme-fitness 
+fi
+
+if tmc workspace get $(yq r $PARAMS_YAML acme-fitness.tmc-workspace) 2>&1 > /dev/null ; then
+	tmc workspace delete $(yq r $PARAMS_YAML acme-fitness.tmc-workspace)
+fi
+set -e 
+
+tmc cluster delete -m attached -p attached $VMWARE_ID-$(yq r $PARAMS_YAML workload-cluster.name)-$(yq r $PARAMS_YAML iaas) --force
 
 tkg set mc $(yq r $PARAMS_YAML management-cluster.name)
 tkg delete cluster $(yq r $PARAMS_YAML workload-cluster.name) --yes

--- a/scripts/tmc-attach.sh
+++ b/scripts/tmc-attach.sh
@@ -36,7 +36,7 @@ tmc cluster attach \
   --name $VMWARE_ID-$CLUSTER_NAME-$IAAS \
   --labels origin=$VMWARE_ID \
   --labels iaas=$IAAS \
-  --group $TMC_CLUSTER_GROUP \
+  --cluster-group $TMC_CLUSTER_GROUP \
   --output generated/$CLUSTER_NAME/tmc.yaml
 kubectl apply -f generated/$CLUSTER_NAME/tmc.yaml
 echo "$CLUSTER_NAME registered with TMC"

--- a/scripts/tmc-policy.sh
+++ b/scripts/tmc-policy.sh
@@ -15,4 +15,8 @@ IAAS=$(yq r $PARAMS_YAML iaas)
 
 VMWARE_ID=$(yq r $PARAMS_YAML vmware-id)
 
-tmc cluster iam add-binding $VMWARE_ID-$CLUSTER_NAME-$IAAS --role $ROLE --groups $POLICY_GROUPS
+tmc cluster iam add-binding $VMWARE_ID-$CLUSTER_NAME-$IAAS \
+  --management-cluster-name attached \
+  --provisioner-name attached \
+  --role $ROLE \
+  --groups $POLICY_GROUPS


### PR DESCRIPTION
TL;DR
-----

Implements a small set of changes to support TMC 0.2 and TKG v1.2

Details
-------

Makes a few changes to the scripts to work with the latest versions
of the `tkg` and `tmc` command-line tools. Specifically does not 
address the changes in TKG extension management that TKG v1.2
introduces. This means that the current implementation requires 
the TKG 1.1 versions of the extensions to succeed.