### PR TITLE
Enables Dex & Harbor to trust Let's Encrypt

### DIFF
--- a/harbor/generate-and-apply-harbor-yaml.sh
+++ b/harbor/generate-and-apply-harbor-yaml.sh
@@ -33,7 +33,6 @@ yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "expose.ingress.ho
 yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "expose.ingress.hosts.notary" $NOTARY_CN  
 yq write generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "externalURL" https://$HARBOR_CN
 
-# Check for Blob storage type
 HARBOR_BLOB_STORAGE_TYPE=$(yq r $PARAMS_YAML harbor.blob-storage.type)
 if [ "s3" == "$HARBOR_BLOB_STORAGE_TYPE" ]; then
   yq d generated/$CLUSTER_NAME/harbor/harbor-values.yaml -i "persistence.persistentVolumeClaim"
@@ -47,15 +46,19 @@ if [ "s3" == "$HARBOR_BLOB_STORAGE_TYPE" ]; then
 fi
 
 helm repo add harbor https://helm.goharbor.io
-helm template harbor harbor/harbor -f generated/$CLUSTER_NAME/harbor/harbor-values.yaml --namespace harbor > generated/$CLUSTER_NAME/harbor/helm-manifest.yaml
+# generate the helm manifest and make sure the core pod trusts let's encrypt
+helm template harbor harbor/harbor -f generated/$CLUSTER_NAME/harbor/harbor-values.yaml --namespace harbor | 
+  ytt -f - -f overlay/trust-certificate --ignore-unknown-comments \
+    --data-value certificate="$(cat keys/letsencrypt-ca.pem)" \
+    --data-value ca=letsencrypt > generated/$CLUSTER_NAME/harbor/helm-manifest.yaml
 
 kapp deploy -a harbor \
   -n tanzu-kapp \
   --into-ns harbor \
   -f generated/$CLUSTER_NAME/harbor/01-namespace.yaml \
   -f generated/$CLUSTER_NAME/harbor/02-certs.yaml \
-  -f generated/$CLUSTER_NAME/harbor/helm-manifest.yaml  \
-  -y
+  -f generated/$CLUSTER_NAME/harbor/helm-manifest.yaml \
+  -y 
 
 echo "Okta OIDC Configurtion Values..."
 echo "Auth Mode: OIDC"

--- a/overlay/trust-certificate/configmap.yaml
+++ b/overlay/trust-certificate/configmap.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: #@ "{}-ca-cert".format(data.values.ca)
+  #@ if data.values.namespace:
+  namespace: #@ data.values.namespace
+  #@ end
 data:
   ca.crt: #@ data.values.certificate
   

--- a/overlay/trust-certificate/values.yaml
+++ b/overlay/trust-certificate/values.yaml
@@ -2,3 +2,4 @@
 ---
 ca:
 certificate:
+namespace:

--- a/scripts/generate-and-apply-dex-yaml.sh
+++ b/scripts/generate-and-apply-dex-yaml.sh
@@ -44,6 +44,8 @@ else
   sed -i -e 's/$OKTA_DEX_APP_CLIENT_SECRET/'$OKTA_DEX_APP_CLIENT_SECRET'/g' generated/$CLUSTER_NAME/dex/04-cm.yaml
 fi
 
+# add the letsencrypt certificate to the configmap as another entry
+yq write -d0 generated/$CLUSTER_NAME/dex/04-cm.yaml -i 'data."letsencrypt.pem"' -- "$(cat keys/letsencrypt-ca.pem)"
 
 kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/01-namespace.yaml
 kubectl apply -f generated/$CLUSTER_NAME/dex/02-service.yaml
@@ -53,6 +55,10 @@ kubectl apply -f generated/$CLUSTER_NAME/dex/04-cm.yaml
 kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/05-rbac.yaml
 
 # Same environment variables set previously
+if kubectl -n tanzu-system-auth get secret oidc ; then
+  kubectl -n tanzu-system-auth delete secret oidc 
+fi
+
 kubectl create secret generic oidc \
    --from-literal=clientId=$OKTA_DEX_APP_CLIENT_ID \
    --from-literal=clientSecret=$OKTA_DEX_APP_CLIENT_SECRET \
@@ -65,4 +71,10 @@ while kubectl get certificates -n tanzu-system-auth dex-cert | grep True ; [ $? 
 	sleep 5s
 done   
 
-kubectl apply -f tkg-extensions/authentication/dex/aws/oidc/06-deployment.yaml
+# inject the Let's Encrypt' ca cert as a trusted certificate
+ytt -f tkg-extensions/authentication/dex/aws/oidc/06-deployment.yaml -f overlay/trust-certificate --ignore-unknown-comments \
+    --data-value namespace=tanzu-system-auth \
+    --data-value certificate="$(cat keys/letsencrypt-ca.pem)" \
+    --data-value ca=letsencrypt > generated/$CLUSTER_NAME/dex/06-deployment.yaml
+ 
+kubectl apply -f generated/$CLUSTER_NAME/dex/06-deployment.yaml 


### PR DESCRIPTION
TL;DR
-----

Updates Dex and Harbor configurations so that deployed pods will
trust Let's Encrypt as a CA

Details
-------

Addreses a challenge I unearthed when using a custom URL (and thus
certificate) for my Okta endpoint. My custom endpoint uses a Let's
Encrypt certificate and the container images used by Dex and Harbor
do not include Let's Encrypt as a trusted certificate. This change
use a YTT overlay to both create a ConfigMap including the Let's
Encrypt CA cert and mount it as a volume so that OpenSSL will see
that certificate as a trusted one.